### PR TITLE
Add sentry-cli to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ php7.3-zip
 RUN mkdir -p /etc/ssl/certs && update-ca-certificates
 RUN mkdir -p /var/log/supervisord/apps
 
+# Install sentry-cli
+RUN curl -sL https://sentry.io/get-cli/ | bash
+
 # Install composer
 RUN php -r "readfile('https://getcomposer.org/installer');" | php && \
    mv composer.phar /usr/bin/composer && \


### PR DESCRIPTION
We use this a lot in CI, so make sure we don't have to install it every time